### PR TITLE
Extend POST parameter handling to PUT requests as well

### DIFF
--- a/Sming/SmingCore/DataSourceStream.cpp
+++ b/Sming/SmingCore/DataSourceStream.cpp
@@ -310,8 +310,8 @@ void TemplateFileStream::setVarsFromRequest(const HttpRequest& request)
 {
 	if (request.requestGetParameters != NULL)
 		templateData.setMultiple(*request.requestGetParameters);
-	if (request.requestPostParameters != NULL)
-		templateData.setMultiple(*request.requestPostParameters);
+	if (request.requestPostPutParameters != NULL)
+		templateData.setMultiple(*request.requestPostPutParameters);
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/Sming/SmingCore/Network/HttpRequest.h
+++ b/Sming/SmingCore/Network/HttpRequest.h
@@ -39,14 +39,14 @@ public:
 	bool isWebSocket();
 
 	String getQueryParameter(String parameterName, String defaultValue = "");
-	String getPostParameter(String parameterName, String defaultValue = "");
+	String getPostPutParameter(String parameterName, String defaultValue = "");
 	String getHeader(String headerName, String defaultValue = "");
 	String getCookie(String cookieName, String defaultValue = "");
 	String getBody();
 
 public:
 	HttpParseResult parseHeader(HttpServer *server, pbuf* buf);
-	HttpParseResult parsePostData(HttpServer *server, pbuf* buf);
+	HttpParseResult parsePostPutData(HttpServer *server, pbuf* buf);
 	String extractParsingItemsList(String& buf, int startPos, int endPos,
 			char delimChar, char endChar,
 			HashMap<String, String>* resultItems);
@@ -57,9 +57,9 @@ private:
 	String tmpbuf;
 	HashMap<String, String> *requestHeaders;
 	HashMap<String, String> *requestGetParameters;
-	HashMap<String, String> *requestPostParameters;
+	HashMap<String, String> *requestPostPutParameters;
 	HashMap<String, String> *cookies;
-	int postDataProcessed;
+	int postPutDataProcessed;
 	int headerDataProcessed;
 	char *bodyBuf;
 

--- a/Sming/SmingCore/Network/HttpServerConnection.cpp
+++ b/Sming/SmingCore/Network/HttpServerConnection.cpp
@@ -58,8 +58,9 @@ err_t HttpServerConnection::onReceive(pbuf *buf)
 
 			String contType = request.getContentType();
 			contType.toLowerCase();
-			if (request.getContentLength() > 0 && request.getRequestMethod() == RequestMethod::POST)
-				state = eHCS_ParsePostData;
+			if (request.getContentLength() > 0 && (request.getRequestMethod() == RequestMethod::POST \
+				|| request.getRequestMethod() == RequestMethod::PUT))
+				state = eHCS_ParsePostPutData;
 					else
 				state = eHCS_ParsingCompleted;
 		}
@@ -69,20 +70,20 @@ err_t HttpServerConnection::onReceive(pbuf *buf)
 		server->processWebSocketFrame(buf, *this);
 	}
 
-	if (state == eHCS_ParsePostData)
+	if (state == eHCS_ParsePostPutData)
 	{
-		HttpParseResult res = request.parsePostData(server, buf);
+		HttpParseResult res = request.parsePostPutData(server, buf);
 		if (res == eHPR_Wait)
-			debugf("POST WAIT");
+			debugf("%s WAIT", request.getRequestMethod().c_str());
 		else if (res == eHPR_Failed)
 		{
-			debugf("POST FAILED");
+			debugf("%s FAILED", request.getRequestMethod().c_str());
 			response.badRequest();
 			sendError();
 		}
 		else if (res == eHPR_Successful)
 		{
-			debugf("POST Parsed");
+			debugf("%s Parsed", request.getRequestMethod().c_str());
 			state = eHCS_ParsingCompleted;
 		}
 	}

--- a/Sming/SmingCore/Network/HttpServerConnection.h
+++ b/Sming/SmingCore/Network/HttpServerConnection.h
@@ -19,7 +19,7 @@ class HttpServer;
 enum HttpConnectionState
 {
 	eHCS_Ready,
-	eHCS_ParsePostData,
+	eHCS_ParsePostPutData,
 	eHCS_ParsingCompleted,
 	eHCS_Sending,
 	eHCS_WebSocketFrames,


### PR DESCRIPTION
For some reason, we didn't handle parameters supplied with PUT requests as we did with POST requests. This fixes that.
